### PR TITLE
remove manual cache handling in PorudctServiceImpl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
 
         stage('Build') {
             steps {
-                sh '/var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/Maven_3.9.6/bin/mvn clean'
                 sh '/var/jenkins_home/tools/hudson.tasks.Maven_MavenInstallation/Maven_3.9.6/bin/mvn verify'
             }
         }


### PR DESCRIPTION
Remove manually updating the cache of list objects when changing a single element in the database, was causing null / concurrency problems.

Cache will be evicted every few minutes instead.

